### PR TITLE
Adding the ability to host Owin middlewares over FastCGI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ TestResults
 *.log
 *.pid
 packages
+/.vs

--- a/FastCgi.Owin/Constants.cs
+++ b/FastCgi.Owin/Constants.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Grillisoft.FastCgi.Owin
+{
+    internal static class Constants
+    {
+        public static readonly KeyValuePair<string, object> OwinVersion = new KeyValuePair<string, object>("owin.Version", "1.0");
+
+        // Owin Spec states host SHOULD send a reason phrase according to RFC 2616 section 6.1.1 when not supplied by the application 
+        public static readonly IReadOnlyDictionary<int, string> ReasonPhrases = new ReadOnlyDictionary<int, string>(new Dictionary<int, string>(){
+            { 100, "Continue" },
+            { 101, "Switching Protocols" },
+            { 200, "OK" },
+            { 201, "Created" },
+            { 202, "Accepted" },
+            { 203, "Non-Authoritative Information" },
+            { 204, "No Content" },
+            { 205, "Reset Content" },
+            { 206, "Partial Content" },
+            { 300, "Multiple Choices" },
+            { 301, "Moved Permanently" },
+            { 302, "Found" },
+            { 303, "See Other" },
+            { 304, "Not Modified" },
+            { 305, "Use Proxy" },
+            { 307, "Temporary Redirect" },
+            { 400, "Bad Request" },
+            { 401, "Unauthorized" },
+            { 402, "Payment Required" },
+            { 403, "Forbidden" },
+            { 404, "Not Found" },
+            { 405, "Method Not Allowed" },
+            { 406, "Not Acceptable" },
+            { 407, "Proxy Authentication Required" },
+            { 408, "Request Time-out" },
+            { 409, "Conflict" },
+            { 410, "Gone" },
+            { 411, "Length Required" },
+            { 412, "Precondition Failed" },
+            { 413, "Request Entity Too Large" },
+            { 414, "Request-URI Too Large" },
+            { 415, "Unsupported Media Type" },
+            { 416, "Requested range not satisfiable" },
+            { 417, "Expectation Failed" },
+            { 500, "Internal Server Error" },
+            { 501, "Not Implemented" },
+            { 502, "Bad Gateway" },
+            { 503, "Service Unavailable" },
+            { 504, "Gateway Time-out" },
+            { 505, "HTTP Version not supported" }
+        });
+    }
+}

--- a/FastCgi.Owin/FastCgi.Owin.csproj
+++ b/FastCgi.Owin/FastCgi.Owin.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Grillisoft.FastCgi.Owin</RootNamespace>
+    <AssemblyName>Grillisoft.FastCgi.Owin</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Owin, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.0.0\lib\net451\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Constants.cs" />
+    <Compile Include="OwinChannel.cs" />
+    <Compile Include="OwinChannelFactory.cs" />
+    <Compile Include="OwinRequest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FastCgi\FastCgi.csproj">
+      <Project>{a3c516b6-046b-44c2-9387-2d01646589c9}</Project>
+      <Name>FastCgi</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/FastCgi.Owin/OwinChannel.cs
+++ b/FastCgi.Owin/OwinChannel.cs
@@ -1,0 +1,20 @@
+﻿using Grillisoft.FastCgi.Protocol;
+
+namespace Grillisoft.FastCgi.Owin
+{
+    public class OwinChannel : SimpleFastCgiChannel
+    {
+        Microsoft.Owin.OwinMiddleware pipeline;
+
+        public OwinChannel(ILowerLayer layer, ILoggerFactory loggerFactory, Microsoft.Owin.OwinMiddleware pipeline)
+            : base(layer, loggerFactory)
+        {
+            this.pipeline = pipeline;
+        }
+
+        protected override Request CreateRequest(ushort requestId, BeginRequestMessageBody body)
+        {
+            return new OwinRequest(requestId, body, pipeline);
+        }
+    }
+}

--- a/FastCgi.Owin/OwinChannelFactory.cs
+++ b/FastCgi.Owin/OwinChannelFactory.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Grillisoft.FastCgi;
+using Grillisoft.FastCgi.Protocol;
+using Microsoft.Owin;
+using Microsoft.Owin.Builder;
+using Owin;
+
+namespace Grillisoft.FastCgi.Owin
+{
+    public class OwinChannelFactory : IFastCgiChannelFactory
+    {
+        private readonly ILoggerFactory loggerFactory;
+        private readonly Action<IAppBuilder> appInitializer;
+
+        public OwinChannelFactory(ILoggerFactory loggerFactory, Action<IAppBuilder> appInitializer)
+        {
+            this.loggerFactory = loggerFactory;
+            this.appInitializer = appInitializer;
+        }
+
+        public FastCgiChannel CreateChannel(ILowerLayer lowerLayer)
+        {
+            IAppBuilder appBuilder = new AppBuilder();
+            appBuilder.Properties.Add(Constants.OwinVersion);
+            appInitializer(appBuilder);
+
+            OwinMiddleware pipeline = appBuilder.Build<OwinMiddleware>();
+            return new OwinChannel(lowerLayer, loggerFactory, pipeline);
+        }
+    }
+}

--- a/FastCgi.Owin/OwinRequest.cs
+++ b/FastCgi.Owin/OwinRequest.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Grillisoft.FastCgi.Protocol;
+using Microsoft.Owin;
+
+namespace Grillisoft.FastCgi.Owin
+{
+    public class OwinRequest : Request
+    {
+        private readonly OwinMiddleware pipeline;
+        private readonly OwinContext context = new OwinContext();
+        private List<Tuple<Action<object>, object>> onSendHeadersCallbacks = new List<Tuple<Action<object>, object>>();
+        private readonly MemoryStream responseBody = new MemoryStream();
+        private readonly CancellationTokenSource cts = new CancellationTokenSource();
+
+        public OwinRequest(ushort id, BeginRequestMessageBody body, OwinMiddleware pipeline) : base(id, body)
+        {
+            this.pipeline = pipeline;
+            context.Set<Action<Action<object>, object>>("server.OnSendingHeaders", RegisterOnSendingHeadersCallback);
+        }
+
+        public override void Abort()
+        {
+            cts.Cancel();
+        }
+
+        public override void Execute()
+        {
+            try
+            {
+                SetOwinContextValues();
+
+                using (var task = pipeline.Invoke(context))
+                {
+                    task.Wait();
+                }
+
+                SendHeaders();
+                responseBody.Position = 0;
+                responseBody.CopyTo(this.OutputStream);
+            }
+            // TODO: Catch exceptions and log
+            finally
+            {
+                this.End();
+                this.responseBody.Dispose();
+                this.cts.Dispose();
+            }
+        }
+
+        private void SetOwinContextValues()
+        {
+            context.Environment.Add(Constants.OwinVersion);
+            context.Request.CallCancelled = cts.Token;
+            context.Request.Body = this.InputStream.Length == 0 ? Stream.Null : this.InputStream;
+            context.Response.Body = responseBody;
+            var headers = context.Request.Headers;
+
+            foreach (var nvp in this.Parameters)
+            {
+                string uName = nvp.Name.ToUpperInvariant();
+                switch (uName)
+                {
+                    case "SERVER_PROTOCOL":
+                        context.Request.Protocol = nvp.Value;
+                        continue;
+                    case "REQUEST_METHOD":
+                        context.Request.Method = nvp.Value.ToUpperInvariant();
+                        continue;
+                    case "QUERY_STRING":
+                        context.Request.QueryString = new QueryString(nvp.Value);
+                        continue;
+                    case "HTTPS":
+                        context.Request.Scheme = nvp.Value.Equals("on", StringComparison.OrdinalIgnoreCase) ? "http" : "http";
+                        continue;
+                    case "PATH_INFO":
+                        context.Request.PathBase = new PathString(string.Empty);
+                        context.Request.Path = new PathString(nvp.Value);
+                        continue;
+                }
+
+                if (uName.StartsWith("HTTP_"))
+                {
+                    headers.Add(uName.Substring(5).Replace('_', '-'), new string[] { nvp.Value } );
+                }
+            }
+
+            context.Response.Protocol = context.Request.Protocol;
+        }
+
+        private void SendHeaders()
+        {
+            foreach (var callbackTuple in onSendHeadersCallbacks)
+            {
+                callbackTuple.Item1(callbackTuple.Item2);
+            }
+
+            using (var writer = new StreamWriter(this.OutputStream, Encoding.ASCII, 1024, true))
+            {
+                writer.WriteLine($"Status: {context.Response.StatusCode} {context.Response.ReasonPhrase ?? Constants.ReasonPhrases[context.Response.StatusCode]}");
+
+                foreach (var header in context.Response.Headers)
+                {
+                    writer.WriteLine($"{header.Key}: {string.Join(", ", header.Value)}");
+                }
+
+                if (!context.Response.ContentLength.HasValue)
+                {
+                    writer.WriteLine($"Content-Length: {responseBody.Length}");
+                }
+
+                writer.WriteLine();
+            }
+        }
+
+        private void RegisterOnSendingHeadersCallback(Action<object> callback, object state)
+        {
+            onSendHeadersCallbacks.Add(Tuple.Create(callback, state));
+        }
+    }
+}

--- a/FastCgi.Owin/Properties/AssemblyInfo.cs
+++ b/FastCgi.Owin/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("FastCgi.Owin")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("FastCgi.Owin")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("22f4fd2e-f0d6-4eaf-84fc-d3f048c4a3e6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/FastCgi.Owin/packages.config
+++ b/FastCgi.Owin/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Owin" version="4.0.0" targetFramework="net451" />
+  <package id="Owin" version="1.0" targetFramework="net40" />
+</packages>

--- a/FastCgi.sln
+++ b/FastCgi.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2000
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastCgi", "FastCgi\FastCgi.csproj", "{A3C516B6-046B-44C2-9387-2D01646589C9}"
 EndProject
@@ -22,6 +22,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImmutableArray", "ImmutableArray\ImmutableArray.csproj", "{AFE9FDDE-332C-41A5-8DA5-6C974F9E6956}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastCgi.Loggers.Log4Net", "FastCgi.Loggers.Log4Net\FastCgi.Loggers.Log4Net.csproj", "{EE31060B-980B-4E24-AE84-0DF6A0F0E95D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastCgi.Owin", "FastCgi.Owin\FastCgi.Owin.csproj", "{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -103,9 +105,24 @@ Global
 		{EE31060B-980B-4E24-AE84-0DF6A0F0E95D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{EE31060B-980B-4E24-AE84-0DF6A0F0E95D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{EE31060B-980B-4E24-AE84-0DF6A0F0E95D}.Release|x86.ActiveCfg = Release|Any CPU
+		{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}.Debug|x86.Build.0 = Debug|Any CPU
+		{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}.Release|x86.ActiveCfg = Release|Any CPU
+		{22F4FD2E-F0D6-4EAF-84FC-D3F048C4A3E6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E05C9E07-8231-4113-A982-6ACD8B39821A}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = FastCgi.Server\FastCgi.Server.csproj

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ sharpfastcgi
 ============
 
 C# fastcgi protocol implementation plus some usage examples.
-A good example on how to self-host your web application without the need of iis or mono.
+A good example on how to self-host your web application without the need of IIS or Mono.
 
 The purpose of this implementation is to have a more reliable solution than the one
 offered with Mono and also a cleaner and reusable implementation of the protocol
@@ -21,6 +21,73 @@ You can run the first example/test following this procedure:
 - start FastCgi.Test exe within visual studio or from a command prompt (in this case you will need to build it first)
 - with a browser goto http://localhost:8082/info.aspx or http://localhost:8082/test.aspx
 
+Example (Owin)
+==============
+
+sharpfastcgi now has an Owin-compatible ChannelFactory that allows you to run any
+Owin-compatible middleware as a FastCGI application.  It has been tested with Microsoft 
+WebAPI 5.2.3 and with the various Microsoft security middlewares for authentication to
+ADFS, Facebook, Twitter, etc.
+
+A minimal example for IIS would look like this:
+
+```c#
+    static class Program
+    {
+        static int Main(string[] args)
+        {
+            var logger = LoggerFactory.Create("Owin Test");
+            logger.Log(LogLevel.Info, "Starting fastcgi server");
+
+            var server = CreateServer();
+            server.Start();
+
+            while (true)
+            {
+                Thread.Sleep(1000);
+            }
+        }
+
+        private static IFastCgiServer CreateServer()
+        {
+            return new IisServer(new OwinChannelFactory(LoggerFactory, applicationRegistration), LoggerFactory);
+        }
+
+        private static ILoggerFactory _loggerFactory;
+
+        private static ILoggerFactory LoggerFactory
+        {
+            get
+            {
+                if (_loggerFactory != null)
+                    return _loggerFactory;
+
+                return _loggerFactory = new Grillisoft.FastCgi.Loggers.Log4Net.LoggerFactory();
+            }
+        }
+
+        static void applicationRegistration(IAppBuilder app)
+        {
+			// Register your Owin middlewares here
+			// This example uses ADFS Bearer Auth and WebAPI
+
+            var configuration = new HttpConfiguration();
+
+            app.UseActiveDirectoryFederationServicesBearerAuthentication(
+                new ActiveDirectoryFederationServicesBearerAuthenticationOptions
+                {
+                    MetadataEndpoint ="MyMetadataEndpoint",
+                    TokenValidationParameters = new TokenValidationParameters()
+                    {
+                        ValidAudience = "MyAudience"
+                    }
+                });
+
+            app.UseWebApi(configuration);
+        }
+    }
+```
+
 Documentation
 ============
-You can also read this article I wroute about this library so you can have a deeper understanding on how it works: http://www.codeproject.com/Articles/388040/FastCGI-NET-and-ASP-NET-self-hosting
+You can also read this article I wrote about this library so you can have a deeper understanding of how it works: http://www.codeproject.com/Articles/388040/FastCGI-NET-and-ASP-NET-self-hosting


### PR DESCRIPTION
My organization had an Owin-based web service that unfortunately needed to call out to a legacy 3rd party component that is not thread safe and is completely outside of our control.  Therefore, we could not host our web service in ASP.NET and needed something like FastCGI to provide process isolation for requests to prevent the memory corruption, etc, we were seeing when using the 3rd party component.

In order to not have to rewrite our entire web service and in order to leverage the many Owin middlewares out there for web frameworks and authentication, I decided to implement an Owin-compliant FastCGI server.  Your project is probably the best written .NET FastCGI implementation--especially for IIS, which we use extensively.

The library in this pull request is now being used in production for us and has solved many of the threading woes we were seeing while hosting non-threadsafe components in an ASP.NET environment.

I look forward to your comments and suggestions.